### PR TITLE
Handle MS Basic with 0 bytes used

### DIFF
--- a/msstats.py
+++ b/msstats.py
@@ -689,7 +689,8 @@ def process_google_service_account(service_account):
         for point in result.points:
             if point.value.int64_value > BytesUsedForCache:
                 BytesUsedForCache = point.value.int64_value
-        metric_points[database][node_id]['BytesUsedForCache'] = BytesUsedForCache
+        if database in metric_points:
+           metric_points[database][node_id]['BytesUsedForCache'] = BytesUsedForCache
 
 
     # CacheHits	


### PR DESCRIPTION
Handle MS Basic with 0 bytes used.  This fix is to prevent the KeyError when encountering a MemoryStore Basic instance with 0 bytes used for cache [BytesUsedForCache].