### PR TITLE
Concatenate project-id with database-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The script will run on any system with Python 3.6 or greater installed.
 Download the repository
 
 ```
-git clone https://github.com/gmflau/msstats && cd msstats
+git clone https://github.com/Redislabs-Solution-Architects/msstats && cd msstats
 ```
 
 Prepare and activate the virtual environment

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The script will run on any system with Python 3.6 or greater installed.
 Download the repository
 
 ```
-git clone https://github.com/Redislabs-Solution-Architects/msstats && cd msstats
+git clone https://github.com/gmflau/msstats && cd msstats
 ```
 
 Prepare and activate the virtual environment

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The script will run on any system with Python 3.6 or greater installed.
 Download the repository
 
 ```
-git clone https://github.com/Redislabs-Solution-Architects/msstats && cd msstats
+git clone https://github.com/gmflau/msstats && cd msstats
 ```
 
 Prepare and activate the virtual environment

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ The script will purely use google cloud monitoring api for getting the metrics. 
 This script by no means will affect the performance and the data stored in the Redis databases it is scanning.
 
 
+## Prerequisites 
+### Software to Install
+* [gcloud command line](https://cloud.google.com/sdk/docs/install)
+* [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+    
 ## Installation
 
 The script will run on any system with Python 3.6 or greater installed.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,31 @@ Copy your service account .json files in the root directory of the project:
 cp path/to/service_account.json .
 ```
 
-Execute 
+Grant monitoring.viewer role to the service account in all associated Google Cloud projects
 
 ```
-python msstats.py
+./grant_sa_monitoring_viewer.sh <service_account>
+
+For example,
+./grant_sa_monitoring_viewer.sh gmflau-sa@gcp-dev-day-nyc.iam.gserviceaccount.com
+```
+
+Execute
+
+```
+./get_msstats.sh <service_account>
+
+For example,
+./get_msstats.sh gmflau-sa@gcp-dev-day-nyc.iam.gserviceaccount.com
+```
+
+Remove monitoring.viewer role from the service account in all associated Google Cloud projects 
+
+```
+./remove_sa_monitoring_viewer.sh <service_account>
+
+For example,
+./remove_sa_monitoring_viewer.sh gmflau-sa@gcp-dev-day-nyc.iam.gserviceaccount.com
 ```
 
 When finished do not forget to deactivate the virtual environment

--- a/get_msstats.sh
+++ b/get_msstats.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 service_account"
-    exit 1
-fi
-
 projects=$(gcloud projects list | awk 'NR>1 {print $1}')
 
 timestamp=$(date +"%Y%m%d_%H%M%S")

--- a/get_msstats.sh
+++ b/get_msstats.sh
@@ -7,6 +7,8 @@ fi
 
 projects=$(gcloud projects list | awk 'NR>1 {print $1}')
 
+timestamp=$(date +"%Y%m%d_%H%M%S")
+
 echo "$projects" | while read -r project_id; do
-    python msstats.py -p $project_id
+    python msstats.py -p $project_id -r ms-report-${timestamp}
 done

--- a/get_msstats.sh
+++ b/get_msstats.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 service_account"
+    exit 1
+fi
+
+projects=$(gcloud projects list | awk 'NR>1 {print $1}')
+
+echo "$projects" | while read -r project_id; do
+    python msstats.py -p $project_id
+done

--- a/grant_sa_monitoring_viewer.sh
+++ b/grant_sa_monitoring_viewer.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 service_account"
+    exit 1
+fi
+
+projects=$(gcloud projects list | awk 'NR>1 {print $1}')
+
+echo "$projects" | while read -r project_id; do
+    project_number=$(gcloud projects describe ${project_id} --format="value(projectNumber)")
+    gcloud projects add-iam-policy-binding ${project_number} --member=serviceAccount:$1 --role='roles/monitoring.viewer' --condition=None
+done

--- a/msstats.py
+++ b/msstats.py
@@ -629,9 +629,8 @@ def process_google_service_account(service_account, projectID):
             metric_points[database] = {}
         if not node_id in metric_points[database]:
             metric_points[database][node_id] = { 
-                "Project ID": project_id,
                 "Source": "MS",
-                "ClusterId": database,
+                "ClusterId": project_id + '.' + database,
                 "NodeId": node_id,
                 "NodeRole": "Master" if result.metric.labels['role'] == 'primary' else "Replica",
                 "NodeType": "",

--- a/msstats.py
+++ b/msstats.py
@@ -566,8 +566,6 @@ def process_google_service_account(service_account, projectID):
 
     if projectID:
         project_id = projectID
-        print("project_id = ", project_id)
-        exit
     else: 
         try:
             f = open (service_account, "r")

--- a/msstats.py
+++ b/msstats.py
@@ -562,17 +562,22 @@ def processMetricPoint(metricPoint):
     
     return processedMetricPoint
 
-def process_google_service_account(service_account):
+def process_google_service_account(service_account, projectID):
 
-    try:
-        f = open (service_account, "r")
-        data = json.loads(f.read())
-        f.close()
-        project_id = data['project_id']
-        if not project_id:
-            raise Exception("Invalid json file")
-    except:
-        return
+    if projectID:
+        project_id = projectID
+        print("project_id = ", project_id)
+        exit
+    else: 
+        try:
+            f = open (service_account, "r")
+            data = json.loads(f.read())
+            f.close()
+            project_id = data['project_id']
+            if not project_id:
+                raise Exception("Invalid json file")
+        except:
+            return
 
     # Set the value GOOGLE_APPLICATION_CREDENTIALS variable
     os.environ.setdefault('GOOGLE_APPLICATION_CREDENTIALS', service_account)
@@ -745,6 +750,14 @@ def main():
         help="The directory to output the results. If the directory does not exist the script will try to create it.", 
         metavar="PATH"
     )
+    parser.add_option(
+        "-p",
+        "--project-id",
+        dest="project_id",
+        default="",
+        help="The Google Cloud Project ID containing MemoryStore instances.",
+        metavar="PROJECT_ID"
+    )
 
     (options, _) = parser.parse_args()
 
@@ -759,7 +772,7 @@ def main():
     # For each service account found try to fetch the clusters metrics using the 
     # google cloud monitoring api metrics
     for service_account in service_accounts:
-        project_id, stats = process_google_service_account(service_account)
+        project_id, stats = process_google_service_account(service_account, options.project_id)
         projects[project_id] = stats
 
     create_workbooks(options.outDir, projects)

--- a/remove_sa_monitoring_viewer.sh
+++ b/remove_sa_monitoring_viewer.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 service_account"
+    exit 1
+fi
+
+projects=$(gcloud projects list | awk 'NR>1 {print $1}')
+
+echo "$projects" | while read -r project_id; do
+    project_number=$(gcloud projects describe ${project_id} --format="value(projectNumber)")
+    gcloud projects remove-iam-policy-binding ${project_number} --member=serviceAccount:$1 --role='roles/monitoring.viewer' --condition=None
+done


### PR DESCRIPTION
To support 1:n (svc to projects) topology, concatenate project-id with database-name in the final ClusterId column in the msstats outputs.