### PR TITLE
Add a few logs

### DIFF
--- a/msstats.py
+++ b/msstats.py
@@ -606,6 +606,7 @@ def process_google_service_account(
 
     client = monitoring_v3.MetricServiceClient()
     project_name = f"projects/{project_id}"
+    print(f"Working on project {project_id}:")
 
     now = time.time()
     seconds = int(now)
@@ -631,6 +632,7 @@ def process_google_service_account(
     # https://cloud.google.com/memorystore/docs/redis/supported-monitoring-metrics
 
     # Call the google cloud "redis.googleapis.com/commands/calls" to get commandstats
+    print(f"Loading the Redis metrics of calls (commandstats)...")
     try:
         results = list(
             client.list_time_series(
@@ -729,6 +731,7 @@ def process_google_service_account(
         }
     )
 
+    print(f"Loading memory usage...")
     try:
         results = client.list_time_series(
             request={
@@ -750,7 +753,7 @@ def process_google_service_account(
         if database in metric_points:
             metric_points[database][node_id]["BytesUsedForCache"] = BytesUsedForCache
 
-    # Retrieve MaxMemory (a.k.a. Capacity)
+    print(f"Loading MaxMemory (aka capacity)...")
     try:
         results = client.list_time_series(
             request={


### PR DESCRIPTION
### Why ?

With ~25 memorystore instance, the execution of the script is very long (>30min)
So more logs helps to know that it still running :)