### PR TITLE
GTI-686: normalize Redis Cluster zone values in Region

### DIFF
--- a/memorystore.py
+++ b/memorystore.py
@@ -24,9 +24,10 @@ Optional:
 import argparse
 import csv
 import os
+import re
 import sys
 import time
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 from collections import defaultdict
 
 from google.oauth2 import service_account
@@ -73,6 +74,28 @@ NODETYPE_LABELS = (
     "service_tier",
     "instance_type",
 )
+
+_GCP_ZONE_RE = re.compile(r"^([a-z]+(?:-[a-z]+)+\d+)-[a-z]$")
+
+
+def _normalize_location(value: Optional[str]) -> Tuple[str, str]:
+    """Split a GCP location label into its (region, zone) pair.
+
+    Encodes GCP's location hierarchy: a zone is always
+    ``<region>-<letter>`` (e.g. ``us-central1-a`` -> region
+    ``us-central1``). When the input matches that shape the parent
+    region is returned as the first element and the original value as
+    the zone. Region-shaped inputs (``us-east4``) and any non-matching
+    string (``""``, ``"global"``, multi-region aliases like ``"us"``)
+    are passed through as the region with an empty zone, so callers
+    never silently lose information.
+    """
+    if not value:
+        return ("", "")
+    match = _GCP_ZONE_RE.match(value)
+    if match:
+        return (match.group(1), value)
+    return (value, "")
 
 
 def _pick(labels: Dict[str, str], keys) -> Optional[str]:
@@ -192,8 +215,9 @@ def _accumulate_commands(results, table, product_name: str, project_id: str):
         entry["InstanceId"] = (
             rlabels.get("instance_id") or rlabels.get("cluster_id") or ""
         )
-        entry["Region"] = _pick(rlabels, REGION_LABELS) or entry["Region"]
-        entry["Zone"] = _pick(rlabels, ZONE_LABELS) or entry["Zone"]
+        region, zone_from_loc = _normalize_location(_pick(rlabels, REGION_LABELS))
+        entry["Region"] = region or entry["Region"]
+        entry["Zone"] = _pick(rlabels, ZONE_LABELS) or zone_from_loc or entry["Zone"]
         entry["NodeType"] = _pick(rlabels, NODETYPE_LABELS) or entry["NodeType"]
 
         # Node role if provided (e.g., 'primary'/'replica')

--- a/test_msstats.py
+++ b/test_msstats.py
@@ -20,6 +20,8 @@ from memorystore import (
     _resolve_inst_key,
     _attach_memory_usage,
     _attach_capacity_scalar,
+    _accumulate_commands,
+    _normalize_location,
 )
 
 
@@ -555,6 +557,82 @@ class TestMemorystore(unittest.TestCase):
         self.assertEqual(
             table["my-project/memorystore-valkey"]["abc123"]["MaxMemory"], 10000000
         )
+
+    def test_normalize_location_zone_form(self):
+        """GCP zone string is split into (region, zone)"""
+        self.assertEqual(
+            _normalize_location("us-central1-a"),
+            ("us-central1", "us-central1-a"),
+        )
+
+    def test_normalize_location_region_form(self):
+        """Region-shaped string is passed through as region, zone blank"""
+        self.assertEqual(_normalize_location("us-east4"), ("us-east4", ""))
+
+    def test_normalize_location_multi_segment_zone(self):
+        """Multi-word region prefix (e.g. asia-northeast1) is handled"""
+        self.assertEqual(
+            _normalize_location("asia-northeast1-c"),
+            ("asia-northeast1", "asia-northeast1-c"),
+        )
+
+    def test_normalize_location_empty_and_none(self):
+        """Empty string and None return ('', '')"""
+        self.assertEqual(_normalize_location(""), ("", ""))
+        self.assertEqual(_normalize_location(None), ("", ""))
+
+    def _make_cmd_ts(self, resource_labels, cmd="GET"):
+        mock_ts = MagicMock()
+        mock_ts.resource.labels = resource_labels
+        mock_ts.metric.labels = {"cmd": cmd}
+        mock_point = MagicMock()
+        mock_point.interval.start_time.timestamp.return_value = 1000.0
+        mock_point.value.int64_value = 1
+        mock_point.value.double_value = 0
+        mock_ts.points = [mock_point]
+        return mock_ts
+
+    def test_accumulate_commands_cluster_location_splits_into_region_and_zone(self):
+        """Redis Cluster: location=<zone> must split into Region + Zone"""
+        table = {}
+        ts = self._make_cmd_ts(
+            {"cluster_id": "c1", "shard_id": "s0", "location": "us-central1-a"}
+        )
+        _accumulate_commands([ts], table, "Redis Cluster", "proj")
+        entry = table["proj/c1"]["s0"]
+        self.assertEqual(entry["Region"], "us-central1")
+        self.assertEqual(entry["Zone"], "us-central1-a")
+
+    def test_accumulate_commands_standalone_keeps_region_and_explicit_zone(self):
+        """Redis standalone: explicit region + zone labels survive untouched"""
+        table = {}
+        ts = self._make_cmd_ts(
+            {
+                "instance_id": "projects/proj/locations/us-central1/instances/r1",
+                "node_id": "n0",
+                "region": "us-central1",
+                "zone": "us-central1-a",
+            }
+        )
+        _accumulate_commands([ts], table, "Redis", "proj")
+        entry = table["projects/proj/locations/us-central1/instances/r1"]["n0"]
+        self.assertEqual(entry["Region"], "us-central1")
+        self.assertEqual(entry["Zone"], "us-central1-a")
+
+    def test_accumulate_commands_standalone_region_only_leaves_zone_blank(self):
+        """Redis standalone: region-only label leaves Zone blank (regex no match)"""
+        table = {}
+        ts = self._make_cmd_ts(
+            {
+                "instance_id": "projects/proj/locations/us-east4/instances/r1",
+                "node_id": "n0",
+                "region": "us-east4",
+            }
+        )
+        _accumulate_commands([ts], table, "Redis", "proj")
+        entry = table["projects/proj/locations/us-east4/instances/r1"]["n0"]
+        self.assertEqual(entry["Region"], "us-east4")
+        self.assertEqual(entry["Zone"], "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

GCP exposes Redis Cluster and Valkey metrics under node-level monitored resources, `redis.googleapis.com/ClusterNode` and `memorystore.googleapis.com/InstanceNode`, whose `location` label is a **zone** (for example `us-central1-b`), not a region.

`memorystore.py` was writing that value verbatim into the `Region` column, so a 4-node cluster spread across 3 zones produced 3 distinct `Region` values for what is actually a single regional cluster.

Downstream, `redis2re` groups by `Region` when sizing, so the same cluster surfaced as multiple duplicate rows in the Salesforce sizing CSV, one per zone, with throughput split across them.

Standalone Redis (`redis_instance`) is unaffected because it exposes `region` explicitly. The bug only appears on cluster / Valkey node-level metrics.

## Fix

- Added `_normalize_location(value) -> (region, zone)` to detect zone-shaped GCP location strings using `^([a-z]+(?:-[a-z]+)+\d+)-[a-z]$` and split them into region and zone components.
- Region-shaped inputs such as `us-east4`, plus values like `us`, `global`, and empty strings, pass through unchanged as the region with an empty zone.
- Applied the helper in `_accumulate_commands` when resolving `REGION_LABELS`.
- Kept explicit `zone` labels as higher precedence when present, preserving existing behavior for resources that already populate both fields.

The regex was validated against the current GCP namespace:
- `130/130` current zones matched and mapped to the correct parent region
- `43/43` current regions were correctly rejected

The multi-segment form `(?:-[a-z]+)+` also supports hypothetical 3+ word-segment regions without changing behavior for names currently in use.

## Verification

Reproduced end-to-end against a live multi-zone cluster, `redislabs-sales-pivotal/memorystore-redis-cluster`, with 2 shards × 2 replicas across `us-central1-{b,c,f}` after generating mixed-command traffic.

| Stage | Before fix | After fix |
| --- | --- | --- |
| `memorystore.py` `Region` column | `us-central1-b`, `us-central1-c`, `us-central1-f` | `us-central1` for all 4 nodes |
| `memorystore.py` `Zone` column | empty | per-node zone (`-b` / `-c` / `-f`) |
| `redis2re` sizing rows for the cluster | **3 duplicates** (`0.01 + 0.01 + 0.10` ops) | **1 consolidated row** (`0.04` ops, throughput aggregated correctly) |

Verification artifacts, including `memorystore.py` CSV before/after and `redis2re` sizing CSV before/after, are attached to the Jira ticket.

## Tests

Added in `test_msstats.py`:

- `test_normalize_location_zone_form` — splits `us-central1-a` into `("us-central1", "us-central1-a")`
- `test_normalize_location_region_form` — passes `us-east4`, `us`, `global`, and `""` through unchanged
- `test_accumulate_commands_cluster_node_splits_zone_from_loc` — drives `_accumulate_commands` with a synthetic `ClusterNode` time series carrying a zone-shaped `location` and asserts the resulting `Region` / `Zone` split

Validation:
- `pytest test_msstats.py` -> `27/27` passing
- `black --check` clean
